### PR TITLE
Fix unsubscribe function and order of fired events

### DIFF
--- a/subscribable.lua
+++ b/subscribable.lua
@@ -23,7 +23,8 @@ local function subscribable(args)
 			s_counter = 0
 		else
 			table.remove(subscribed, subscribed_i[func])
-			table.remove(subscribed_i, func)
+			subscribed_i[func] = nil
+			s_counter = s_counter - 1
 		end
 
 		if self.unsubscribe_callback then self.unsubscribe_callback(func) end

--- a/timed.lua
+++ b/timed.lua
@@ -188,12 +188,15 @@ local function timed(args)
 			is_inter = false --resets intermittent
 			timer:stop()	 --stops itself
 
+			--run subscribed in functions
+			obj:fire(obj.pos, time, dx)
+
 			-- awestore compatibility....
 			if obj.awestore_compat then obj.ended:fire(obj.pos, time, dx) end
+		else
+			--run subscribed in functions
+			obj:fire(obj.pos, time, dx)
 		end
-
-		--run subscribed in functions
-		obj:fire(obj.pos, time, dx)
 	end)
 
 


### PR DESCRIPTION
I noticed a few bugs while switching from awestore to rubato in my config, but was able to fix them.

1. The first is that the `unsubscribe()` function was calling `table.remove()` with the second argument as a function, but `table.remove()` only takes a number representing an index in the table as its second argument. Additionally, the counter tracking the number of subscribed functions was not being decremented.
2. I noticed that when a `timed` object ends  the `ended` object subscribers are fired  before the regular subscribers are fired the last time. This was causing issues in my config, and I think it makes more sense for the regular subscribers to be fired the last time before the ended subscribers.

This PR remedies both these issues based on my testing with my own config.