### PR TITLE
Add an option to instantly end the animaiton

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,11 +1,13 @@
 RUBATO_DEF_RATE = 30
 RUBATO_OVERRIDE_DT = true
+RUBATO_INSTANT = false
 RUBATO_DIR = (...):match("(.-)[^%.]+$").."rubato."
 
 return {
 	--Overarching functions to set defaults
 	set_def_rate = function(rate) RUBATO_DEF_RATE = rate end,
 	set_override_dt = function(value) RUBATO_OVERRIDE_DT = value end,
+	set_instant = function(value) RUBATO_INSTANT = value end,
 
 	--Modules
 	timed = require(RUBATO_DIR.."timed"),

--- a/timed.lua
+++ b/timed.lua
@@ -116,6 +116,7 @@ local function timed(args)
 
 	obj.rate = args.rate or RUBATO_DEF_RATE or 30
 	obj.override_dt = args.override_dt or RUBATO_OVERRIDE_DT or true
+	obj.instant = args.instant or RUBATO_INSTANT or false
 
 	-- hidden properties
 	obj._props = {
@@ -203,6 +204,12 @@ local function timed(args)
 
 	-- Set target and begin interpolation
 	local function set(target_new)
+		if obj.instant then
+			obj.pos = target_new
+			obj:fire(obj.pos, 0, 0)
+			if obj.awestore_compat then obj.ended:fire(obj.pos, time, dx) end
+			return
+		end
 
 		--disallow setting it twice (because it makes it go wonky)
 		if not obj.rapid_set and obj._props.target == target_new then return end

--- a/timed.lua
+++ b/timed.lua
@@ -204,6 +204,10 @@ local function timed(args)
 
 	-- Set target and begin interpolation
 	local function set(target_new)
+		obj.rate = args.rate or RUBATO_DEF_RATE or 30
+		obj.override_dt = args.override_dt or RUBATO_OVERRIDE_DT or true
+		obj.instant = args.instant or RUBATO_INSTANT or false
+
 		if obj.instant then
 			obj.pos = target_new
 			obj:fire(obj.pos, 0, 0)


### PR DESCRIPTION
This is useful for when running a demanding app (game?) and you would rather not waste any performance. 
I'm not sure calling it 'insant' makes the most sense though. Maybe you have a better naming?

Example:
```
  ruled.client.append_rule
    {
        rule_any = { class = { "DemandingApp"  } },
        callback = function (c)
               rubato.set_instant(true)
               c:connect_signal("unmanage", function()
                    rubato.set_instant(false)
               end)
        end
    }
``` 