### PR TITLE
Add Lua 5.1 / LuaJIT compatibility

### DIFF
--- a/timed.lua
+++ b/timed.lua
@@ -291,7 +291,7 @@ local function timed(args)
 	end
 
 	--override to allow calling fire with no arguments
-	function obj:fire(...) args = ({...})[1] and {...} or {obj.pos, obj._time, obj._dt}; for _, func in pairs(obj._subscribed) do func(table.unpack(args)) end end
+	function obj:fire(...) args = ({...})[1] and {...} or {obj.pos, obj._time, obj._dt}; for _, func in pairs(obj._subscribed) do func((table.unpack or unpack)(args)) end end
 
 	--subscribe stuff initially and add callback
 	obj.subscribe_callback = function(func) func(obj.pos, obj._time, obj._dt) end


### PR DESCRIPTION
Many users use awesomewm with luajit, which is based off of lua 5.1. Lua 5.1 uses has the `unpack` function, which is deprecated and replaced by `table.unpack` method in later versions. This patch should fallback on the `unpack` function if `table.unpack` is not available.