### PR TITLE
Luarocks: Put files into their own module directory

### DIFF
--- a/rubato-1.2-1.rockspec
+++ b/rubato-1.2-1.rockspec
@@ -16,9 +16,10 @@ dependencies = {}
 build = {
    type = "builtin",
    modules = {
-      easing = "easing.lua",
-      timed = "timed.lua",
-	  subscribable = "subscribable.lua",
-	  manager = "manager.lua"
+      ["rubato.init"] = "init.lua",
+      ["rubato.easing"] = "easing.lua",
+      ["rubato.timed"] = "timed.lua",
+      ["rubato.subscribable"] = "subscribable.lua",
+      ["rubato.manager"] = "manager.lua"
    }
 }


### PR DESCRIPTION
Hi. So im not a lua expert but:

Prevoiusly all files have been put into your lua libraries folder wich required you to import files directly `require("timed")`. Now they have their own 'rubato' module folder which makes it way easier to see what module you are actually importing `require("rubato").timed....`

Im not sure if it would have even worked before with luarocks because of RUBATO_DIR and RUBATO_MANAGER but it definitely does now.

TLDR:
```
local timed = require("timed")
timed {.....
```
is now
```
local rubato = require("rubato")
rubato.timed {.....
```
and so on
