### PR TITLE
Init Argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Arguments (in the form of a table):
  - `awestore_compat`: make api even *more* similar to awestore's (def. `false`)
  - `log`: it would print additional logs, but there aren't any logs to print right now so it kinda just sits there (def. `false`)
  - `debug`: basically just tags the timed instance. I use it in tandem with `manager.timed.override.forall`
+ - `init`: when `true`, executes `subscribed` function one time initially with the initial `pos` of the animation
 
 All of these values (except awestore_compat and subscribed) are mutable and changing them will change how the animation looks. I do not suggest changing `pos`, however, unless you change the position of what's going to be animated in some other way
 

--- a/timed.lua
+++ b/timed.lua
@@ -314,7 +314,9 @@ local function timed(args)
 	function obj:fire(...) args = ({...})[1] and {...} or {obj.pos, obj._time, obj._dx}; for _, func in pairs(obj._subscribed) do func(unpack(args)) end end
 
 	--subscribe stuff initially and add callback
-	obj.subscribe_callback = function(func) func(obj.pos, obj._time, obj._dt) end
+	if args.init then
+		obj.subscribe_callback = function(func) func(obj.pos, obj._time, obj._dt) end
+	end
 	if args.subscribed ~= nil then obj:subscribe(args.subscribed) end
 
 	-- Metatable for cooler api


### PR DESCRIPTION
I changed the behavior a little by making `rubato.timed` only execute the `subscribed` function on object creation (initially) when the `init` argument is passed to it. In my case this was necessary as some objects used in the `subscribed` function where only defined just before setting `rubato.timed.target` thus when the `subscribed` function was executed prematurely an error was thrown as those objects were always `nil` at that time. Thanks for this **awesome** library!